### PR TITLE
Build windows wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,7 @@ jobs:
 
     strategy:
       matrix:
-#        os: [macos-latest, ubuntu-latest, windows-latest]
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         manylinux-image: [manylinux2014]
 
     steps:
@@ -41,7 +40,8 @@ jobs:
         CIBW_ARCHS: auto64
         CIBW_BEFORE_ALL_LINUX: yum install -y libzstd-devel || apk add zstd-dev
         CIBW_BEFORE_ALL_MACOS: brew install zstd
-        CIBW_BEFORE_ALL_WINDOWS: choco install zstandard
+        CIBW_BEFORE_BUILD_WINDOWS: "python {package}/libzstd/_get_zstd.py && pip install delvewheel"
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
       run: python -m cibuildwheel --output-dir dist
 
     - name: Check Wheels

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,45 +3,6 @@ name: tests
 on: [push, pull_request]
 
 jobs:
-  Code-Checks:
-    name: Code Checks
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Install Dependencies
-      run: |
-        sudo apt-get -y install libzstd-dev clang g++ wget
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade-strategy eager --upgrade cython twine numpy
-        
-    - name: System Information
-      run: |
-        nproc
-        g++ --version
-        clang++ --version
-
-    - name: Check committed Cython source
-      run: |
-        # Note that modification times can't be compared because they are changed by the git checkout
-        python3 setup.py build_clib
-        python3 setup.py build_ext --inplace
-        git status
-        git diff
-        ls -la indexed_zstd/indexed_zstd.cpp
-        if ! git diff --quiet indexed_zstd/indexed_zstd.cpp; then
-          echo -e '\e[31mPlease trigger a rebuild of indexed_zstd.pyx using "python3 setup.py build_ext --inplace --cython" and commit the new file\e[0m'
-          git diff indexed_zstd/indexed_zstd.cpp
-        fi
-
-    - name: Install From Tarball
-      run: |
-        python3 setup.py sdist
-        twine check dist/*
-        python3 -m pip install dist/*.tar.gz
-
   Tests:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ jobs:
         # 3.10 was released 2021-10-04 and end-of-life will be 2026-10-25
         # 3.11 was released 2022-10-24 and end-of-life will be 2027-10-24
         python-version: ['3.7', '3.11']
-        os: [macos-latest, ubuntu-latest]
-        #os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,18 +28,27 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Dependencies
+    - name: Install Dependencies (ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get -y install libzstd-dev g++
 
+    - name: Install Dependencies (windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        python libzstd/_get_zstd.py
+        copy libzstd/lib/libzstd.dll C:\Windows\System32\
+        regsvr32 C:\Windows\System32\libzstd.dll
+
     - name: Install Python Modules
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade-strategy eager --upgrade cibuildwheel cython twine numpy
+        python3 -m pip install --upgrade-strategy eager --upgrade cython twine cibuildwheel
 
     - name: Test Installation From Tarball
       shell: bash
+      env:
+        LIBZSTD_DIR: ${{ github.workspace }}\libzstd  # windows
       run: |
         python3 setup.py sdist
         twine check dist/*
@@ -57,8 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        #os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         manylinux-image: [manylinux2014]
 
     steps:
@@ -87,7 +94,8 @@ jobs:
         CIBW_ARCHS: auto64
         CIBW_BEFORE_ALL_LINUX: yum install -y libzstd-devel || apk add zstd-dev
         CIBW_BEFORE_ALL_MACOS: brew install zstd
-        CIBW_BEFORE_ALL_WINDOWS: choco install zstandard
+        CIBW_BEFORE_BUILD_WINDOWS: "python {package}/libzstd/_get_zstd.py && pip install delvewheel"
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
       run: python -m cibuildwheel --output-dir dist
 
     - name: Check Wheels

--- a/libzstd/_get_zstd.py
+++ b/libzstd/_get_zstd.py
@@ -1,0 +1,48 @@
+"""download the latest zstd release for win64"""
+import io
+import json
+import pathlib
+import platform
+import urllib.request
+import zipfile
+
+if platform.system() != "Windows":
+    print("windows only")
+    raise SystemExit(1)
+
+
+ZSTD_RELEASE_LATEST = "https://api.github.com/repos/facebook/zstd/releases/latest"
+
+with urllib.request.urlopen(ZSTD_RELEASE_LATEST) as response:
+    data = json.load(response)
+
+for asset in data["assets"]:
+    if "win64" in asset["name"]:
+        break
+else:
+    print("no release asset found with 'win64' in filename")
+    raise SystemExit(1)
+
+
+with urllib.request.urlopen(asset["browser_download_url"]) as f:
+    zip_data = f.read()
+
+
+SCRIPT_DIR = pathlib.Path(__file__).parent
+INCLUDE_DIR = SCRIPT_DIR.joinpath("include")
+LIBRARY_DIR = SCRIPT_DIR.joinpath("lib")
+INCLUDE_DIR.mkdir(exist_ok=True)
+LIBRARY_DIR.mkdir(exist_ok=True)
+
+
+with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+    INCLUDE_DIR.joinpath("zstd.h").write_bytes(zf.read("include/zstd.h"))
+    LIBRARY_DIR.joinpath("libzstd.dll").write_bytes(zf.read("dll/libzstd.dll"))
+    try:
+        _libzstd_lib = zf.read("dll/libzstd.lib")
+    except KeyError:
+        _libzstd_lib = zf.read("dll/libzstd.dll.a")
+    # this renames libzstd.dll.a to libzstd.lib for setuptools to work
+    LIBRARY_DIR.joinpath("libzstd.lib").write_bytes(_libzstd_lib)
+
+print("success")


### PR DESCRIPTION
Closes #15 

Add windows wheels.

Still needs to:
- [x] fix test on python 3.11 (fails due to change in dll load behaviour in py38+ https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-python-api)
- [x] do the delocate/auditwheel equivalent on cibuildwheel for windows? https://github.com/adang1345/delvewheel